### PR TITLE
app: add bad hosts HTTP handler with improved behavior

### DIFF
--- a/app/site/site.go
+++ b/app/site/site.go
@@ -97,7 +97,7 @@ func handleBadHosts(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Host {
 	// For known hosts that are not explicitly "allowed", redirect
 	// to the main site.
-	case "aarontaylor.xyz":
+	case "www.ataylor.io", "aarontaylor.xyz", "www.aarontaylor.xyz":
 		r.URL.Host = defaultHost
 		http.Redirect(w, r, r.URL.String(), http.StatusFound)
 	default:

--- a/app/site/site.go
+++ b/app/site/site.go
@@ -40,7 +40,8 @@ func (s *Server) l() *zap.Logger {
 func (s *Server) addr() string {
 	iface := s.c.Interface
 	if iface == "" && s.c.Dev {
-		// Default to localhost in dev to avoid warnings on macos
+		// Default to localhost in dev for a safer default
+		// behavior and to avoid warnings on macos.
 		iface = "127.0.0.1"
 	}
 	return fmt.Sprintf("%s:%d", iface, s.c.Port)
@@ -74,6 +75,8 @@ func (s *Server) router() http.Handler {
 		ContentSecurityPolicy: csp,
 		IsDevelopment:         s.c.Dev,
 	})
+	secureMiddleware.SetBadHostHandler(
+		(http.HandlerFunc)(handleBadHosts))
 
 	return secureMiddleware.Handler(mux)
 }
@@ -83,4 +86,23 @@ func (s *Server) Serve() error {
 	s.l().Info("Serving HTTP requests", zap.String("addr", s.addr()))
 
 	return http.ListenAndServe(s.addr(), s.router())
+}
+
+// Default host to redirect to for known error cases.
+const defaultHost = "ataylor.io"
+
+// handleBadHosts provides an HTTP handler for better behavior for bad
+// hostnames that are not the primary hostname the server is configured for.
+func handleBadHosts(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Host {
+	// For known hosts that are not explicitly "allowed", redirect
+	// to the main site.
+	case "aarontaylor.xyz":
+		r.URL.Host = defaultHost
+		http.Redirect(w, r, r.URL.String(), http.StatusFound)
+	default:
+		// Returning a 4XX error as this is not something the server
+		// itself did wrong.
+		http.Error(w, "Bad Host", http.StatusBadRequest)
+	}
 }

--- a/app/site/site_test.go
+++ b/app/site/site_test.go
@@ -76,10 +76,12 @@ func TestProdServer(t *testing.T) {
 		assert.Contains(t, string(b), "Bad Host")
 	})
 
-	t.Run("known invalid host request", func(t *testing.T) {
+	t.Run("known invalid host redirect", func(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(
-			http.MethodGet, "http://aarontaylor.xyz", nil)
+			http.MethodGet,
+			"http://www.ataylor.io/example?k=v",
+			nil)
 		h.ServeHTTP(rw, req)
 
 		resp := rw.Result()
@@ -87,5 +89,9 @@ func TestProdServer(t *testing.T) {
 		b, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Contains(t, string(b), "Found")
+		assert.Equal(t,
+			"http://ataylor.io/example?k=v",
+			resp.Header.Get("Location"),
+		)
 	})
 }

--- a/app/site/site_test.go
+++ b/app/site/site_test.go
@@ -63,15 +63,29 @@ func TestProdServer(t *testing.T) {
 	h := s.router()
 	assert.NotNil(t, h)
 
-	t.Run("invalid host request", func(t *testing.T) {
+	t.Run("unknown invalid host request", func(t *testing.T) {
 		rw := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "http://hacker.com/", nil)
+		req := httptest.NewRequest(
+			http.MethodGet, "http://hacker.com/", nil)
 		h.ServeHTTP(rw, req)
 
 		resp := rw.Result()
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		b, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Contains(t, string(b), "Bad Host")
+	})
+
+	t.Run("known invalid host request", func(t *testing.T) {
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(
+			http.MethodGet, "http://aarontaylor.xyz", nil)
+		h.ServeHTTP(rw, req)
+
+		resp := rw.Result()
+		assert.Equal(t, http.StatusFound, resp.StatusCode)
+		b, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(b), "Found")
 	})
 }


### PR DESCRIPTION
The default behavior [1] returns a 500 error which makes alerting
on HTTP status codes confusing when sites crawl alternate domains
for the website.

[1] https://github.com/unrolled/secure/blob/d9ab0ac5b2ce84de5ceb163f1b31fc674e22ed59/secure.go#L38-L40