### PR TITLE
robots: reference sitename filename through variable

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,8 +1,7 @@
 # robots.txt file for ataylor.io
 {{- if hugo.IsProduction }}
 # Hello, Robots!
-{{- /* # NOTE: The .Sitemap.Filename variables is not available here. */}}
-Sitemap: {{ "sitemap.xml" | absURL }}
+Sitemap: {{ site.Home.Sitemap.Filename | absURL }}
 User-agent: *
 Disallow:
 {{- else }}


### PR DESCRIPTION
This cleans things up here a bit, based on the suggestion here:
https://discourse.gohugo.io/t/sitemap-variables-unavailable-in-robots-txt-template/36236/2