### PR TITLE
blog: Add post about the implementation of the Go template playground

### DIFF
--- a/content/blog/go-templates/index.md
+++ b/content/blog/go-templates/index.md
@@ -59,12 +59,17 @@ steps:
 1. Decode input data
 1. Execute the template
 
+For executing the template, we also optionally pull in the [sprig][sprigSite]
+template function library, which is commonly used in projects that make use of
+Go template to add a large suite of functions for common tasks. It is optional
+to provide a toggle for whether or not it should be disabled/enabled.
+
 Error handling is a bit "fast and loose" here. I opted to keep things simple by
 returning a single string that will be rendered into the output in order to
 display error messages directly to the user. That could be split out for a more
 customized UI by returning a structured object for the result.
 
-{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/exp/go-templates/main.go#L16-L44" >}}
+{{< emgithub "https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/exp/go-templates/main.go#L24-L60" >}}
 
 With that code in place, we need to build it into the `.wasm` file that will be
 executed within the browser environment. There are two pieces to that puzzle,
@@ -81,7 +86,7 @@ current rule, producing a file called `go-templates.wasm` for us. The latter
 portion of that rule which specifies `$(wildcard *.go **/*.go)` indicates that
 this rule should re-run whenever those files change.
 
-{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/exp/go-templates/Makefile#L9-L17" >}}
+{{< emgithub "https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/exp/go-templates/Makefile#L9-L17" >}}
 
 ## Bringing Wasm into the UI
 
@@ -96,13 +101,13 @@ filename, allowing for longer duration caching in the browser, which is
 particularly useful here since these the Wasm files are somewhat sizable
 (multiple MBs).
 
-{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/assets/js/exp/go-templates.tpl.jsx#L10-L17" >}}
+{{< emgithub "https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/assets/js/exp/go-templates.tpl.jsx#L10-L17" >}}
 
 We then pull in Go's `wasm_exec.js` wrapper in similar fashion, using Hugo
 Pipes, but in this case as it's a standard `.js` file we can put it directly
 within a script tag, SRI hash and all.
 
-{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/layouts/partials/footer.html#L35-L40" >}}
+{{< emgithub "https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/layouts/partials/footer.html#L35-L40" >}}
 
 With those two pieces in place, we are now ready to initialize the Wasm-based
 functionality. The following Javascript function is called from within our
@@ -124,13 +129,13 @@ causes the application to perform it's first template rendering, or we mark the
 error accordingly and display it to the user. The error display is useful here
 in particular because Wasm is not well-supported on older browser environments.
 
-{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/assets/js/exp/playground.jsx#L46-L71" >}}
+{{< emgithub "https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/assets/js/exp/playground.jsx#L57-L82" >}}
 
 The rest of the app is a relatively straightforward Preact (React-style)
 application. It is somewhat monolithic as it is a relatively simple use case,
 but gets the job done. You can see the file in it's entirety here:
 
-[assets/js/exp/playground.jsx](https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/assets/js/exp/playground.jsx)
+[assets/js/exp/playground.jsx](https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/assets/js/exp/playground.jsx)
 
 One interesting piece of that code is where the Wasm code is invoked. The
 `newState` method shown here is a helper to produce the next version of the
@@ -139,14 +144,14 @@ various locations to add the newly rendered template state, using the
 `ExpRenderGoTemplate` global function exposed from the Go Wasm, to the overall
 Preact state.
 
-{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/assets/js/exp/playground.jsx#L27-L44" >}}
+{{< emgithub "https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/assets/js/exp/playground.jsx#L36-L55" >}}
 
 To tie things off, I added a basic end to end test to ensure that the basic
 functionality keeps working moving forward. These tests are written in puppeteer
 and because I already had the puppeteer logic up and running for other areas of
 the website, it was as simple as adding the test case we see here.
 
-{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/e2e/site.test.js#L46-L66" >}}
+{{< emgithub "https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/e2e/site.test.js#L46-L66" >}}
 
 ## Odds and ends
 
@@ -186,11 +191,7 @@ files referencing `syscall/js`. To get around that, you can hopefully do some
 sort of directory-specific customization, which is what I did here for my setup
 of Vim with `gopls`.
 
-{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/exp/go-templates/.vim/coc-settings.json#L3-L6" >}}
-
-Future work on this tool could extended the templating functions provided by the
-standard library with additional ones, such as the
-https://github.com/Masterminds/sprig functionality that is provided in Helm and Hugo.
+{{< emgithub "https://github.com/kujenga/website/blob/66789e78b4ab7bf3a9245e88fd6a272db1653330/exp/go-templates/.vim/coc-settings.json#L3-L6" >}}
 
 If you made it this far I hope that you enjoyed this post, and that you will get
 some utility out of the templating playground itself! If you have any feedback
@@ -226,6 +227,7 @@ Contributions or suggestions would be very welcome!
 [goSyscallJS]: https://pkg.go.dev/syscall/js
 [golangbotWasm]: https://golangbot.com/webassembly-using-go/
 [goSyscallJSFuncOf]: https://pkg.go.dev/syscall/js#FuncOf
+[sprigSite]: https://github.com/Masterminds/sprig
 [hugoPipes]: https://gohugo.io/hugo-pipes/introduction/#find-resources-in-assets
 [wasmInstantiateStreaming]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
 [gopherjs]: https://github.com/gopherjs/gopherjs

--- a/content/blog/go-templates/index.md
+++ b/content/blog/go-templates/index.md
@@ -1,5 +1,5 @@
 +++
-date = "2022-04-24T10:23:25-04:00"
+date = "2022-04-30T13:04:06-04:00"
 title = "Building a Go template playground with Wasm"
 description = """Creating an interactive live parser to experiment with the Go
 templating language, built using WebAssembly and running the Go standard library
@@ -24,7 +24,7 @@ backend languages to the browser. It is built into my [personal site][ghRepo] to
 simplify development and deployment.
 
 **If you just want to jump over to the playground, check it out
-[here][playground].**
+[here]({{< ref "/exp/go-templates" >}}).**
 
 As context for the approach I'll be walking through here, I decided to make the
 Go side of this application as lightweight as possible, pairing it with a
@@ -218,7 +218,6 @@ Contributions or suggestions would be very welcome!
 
 <!-- Links -->
 [wasm]: https://webassembly.org/
-[playground]: /exp/go-templates/
 [ghRepo]: https://github.com/kujenga/website
 [preact]: https://preactjs.com/
 [helm]: https://helm.sh/

--- a/content/blog/go-templates/index.md
+++ b/content/blog/go-templates/index.md
@@ -1,0 +1,22 @@
++++
+date = "2022-04-24T10:23:25-04:00"
+title = "Building a playground for the Go template language with WASM"
+description = """Creating an interactive webpage to experiment with the Go
+templating language, build using WASM to run the Go standard library directly
+in your browser."""
+categories = ['homepage']
+tags = ['Go', 'WASM', 'Templates']
+images = [
+]
+toc = true
++++
+
+This post walks through how I created this webpage, which pulls Go template
+rendering capabilities into the browser with WebAssembly, placing them within a
+dynamic app built with Preact.
+
+If you just want to jump over to the site, check it out [here][playground].
+
+
+<!-- Links -->
+[playground]: /exp/go-templates/

--- a/content/blog/go-templates/index.md
+++ b/content/blog/go-templates/index.md
@@ -1,6 +1,6 @@
 +++
 date = "2022-04-24T10:23:25-04:00"
-title = "Building a Go template language playground with Wasm"
+title = "Building a Go template playground with Wasm"
 description = """Creating an interactive live parser to experiment with the Go
 templating language, built using WebAssembly and running the Go standard library
 directly in your browser."""
@@ -11,26 +11,27 @@ images = [
 toc = true
 +++
 
-This post walks through how I created this [web page][playground], which pulls
-Go template rendering capabilities into the browser with [WebAssembly][wasm]
-(Wasm), placing them within a dynamic app built with [Preact][preact]. I was
-motivated to this after recently seeing the utility of other similar
-environments out there for different programming languages[^others], but to my
-knowledge nothing exists of this nature for Go, despite relatively wide adoption
-of the Go template language for projects like [Helm][helm] and [Hugo][hugo].
-Additionally, I've been interested for a while in incorporating Wasm into an
-actual deployed project, and this seemed like a great opportunity for it, as
-well as chance to play with alternate approaches to help bring what are
-traditionally backend languages to the browser.
+This post walks through how I created the [Go Templates Playground][playground].
+It pulls Go template rendering capabilities directly into your browser with
+[WebAssembly][wasm] (Wasm). I was motivated to this after recently seeing the
+utility of other similar environments out there for different programming
+languages[^others]. The Go template language has relatively wide adoption in
+projects like [Helm][helm] and [Hugo][hugo], which this tool can be used to
+prototype and experiment for. I've also been interested in incorporating Wasm
+into a deployed project, and this was a great opportunity for it, as well as
+chance to play with alternate approaches to help bring what are traditionally
+backend languages to the browser. It is built into my [personal site][ghRepo] to
+simplify development and deployment.
 
 **If you just want to jump over to the playground, check it out
 [here][playground].**
 
 As context for the approach I'll be walking through here, I decided to make the
 Go side of this application as lightweight as possible, pairing it with a
-single-page Javascript application build with [Preact][preact] to handle the
+single-page Javascript application built with [Preact][preact] that handles the
 rendering layer, rather than trying to make rendering happen from within Go as
-well. I'll mention some alternatives near the end of the post.
+well. The result is a fully static page with no server-side logic. I'll mention
+some alternatives near the end of the post.
 
 ## Turning Go into Wasm
 
@@ -49,7 +50,8 @@ walking through the fundamental steps needed to get things working.
 In the below snippet we define a variable called `render` which is a function
 wrapped with the [`syscall/js.FuncOf`][goSyscallJSFuncOf] function. In the last
 line of the snippet, that variable is then set on the `global` object, making it
-available globally on the page that this code is loaded into.
+available globally on the page that this code is loaded into. You can click
+through at the bottom of the snippet to see the full file.
 
 The function itself is relatively straightforward, performing the following
 steps:
@@ -192,7 +194,10 @@ https://github.com/Masterminds/sprig functionality that is provided in Helm and 
 
 If you made it this far I hope that you enjoyed this post, and that you will get
 some utility out of the templating playground itself! If you have any feedback
-or questions, feel free to leave a comment or reach out!
+or questions, feel free to leave a comment or reach out. If you want to
+experiment with the code locally, check out the [README][repoReadme] for the
+repository to install, and you can play around with the files above.
+Contributions or suggestions would be very welcome!
 
 <!-- Citations -->
 [^others]: One inspiration for this project was
@@ -213,6 +218,7 @@ or questions, feel free to leave a comment or reach out!
 <!-- Links -->
 [wasm]: https://webassembly.org/
 [playground]: /exp/go-templates/
+[ghRepo]: https://github.com/kujenga/website
 [preact]: https://preactjs.com/
 [helm]: https://helm.sh/
 [hugo]: https://gohugo.io/
@@ -224,3 +230,4 @@ or questions, feel free to leave a comment or reach out!
 [wasmInstantiateStreaming]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
 [gopherjs]: https://github.com/gopherjs/gopherjs
 [gopherJSJquery]: https://github.com/gopherjs/jquery
+[repoReadme]: https://github.com/kujenga/website#development

--- a/content/blog/go-templates/index.md
+++ b/content/blog/go-templates/index.md
@@ -1,6 +1,6 @@
 +++
 date = "2022-04-24T10:23:25-04:00"
-title = "Building a playground for the Go template language with WASM"
+title = "Building a Go template language playground with WASM"
 description = """Creating an interactive webpage to experiment with the Go
 templating language, build using WASM to run the Go standard library directly
 in your browser."""
@@ -12,11 +12,194 @@ toc = true
 +++
 
 This post walks through how I created this webpage, which pulls Go template
-rendering capabilities into the browser with WebAssembly, placing them within a
-dynamic app built with Preact.
+rendering capabilities into the browser with WebAssembly (WASM), placing them
+within a dynamic app built with Preact. I was motivated to this after recently
+seeing the utility of other similar environments out there for different
+programming languages[^others], but to my knowledge nothing exists of this
+nature for Go, despite relatively wide adoption of the Go template language for
+projects like [Helm][helm] and [Hugo][hugo]. Additionally, I've been interested
+for a while in incorporating WASM into an actual deployed project, and this
+seemed like a great opportunity for it, as well as chance to play with
+alternate approaches to help bring what are traditionally backend languages to
+the browser.
 
-If you just want to jump over to the site, check it out [here][playground].
+**If you just want to jump over to the playground, check it out
+[here][playground].**
 
+As context for the approach I'll be walking through here, I decided to make the
+Go side of this application as lightweight as possible, pairing it with a
+single-page Javascript application build with [Preact][preact] to handle the
+rendering layer, rather than trying to make rendering happen from within Go as
+well. I'll mention some alternatives near the end of the post.
+
+## Turning Go into WASM
+
+As a first step, we put in place a package for the functionality we want to
+expose through WASM. I did this as a separate Go module within the same
+repository, under [exp/go-templates][ghExpTemplates]. Within that file, we
+utilize the standard library (but experimental) [syscall/js][goSyscallJS]
+package to expose basic functionality that will compile a template and render it
+against the input data.
+
+As the WASM support provided by Go is somewhat experimental and not all that
+well documented, I found this webpage
+[golangbot.com/webassembly-using-go/][golangbotWASM] to be a helpful guide,
+walking through the fundamental steps needed to get things working.
+
+In the below snippet we define a variable called `render` which is a function
+wrapped with the [`syscall/js.FuncOf`][goSyscallJSFuncOf] function. That
+variable is then set on the global context, making it available to the page that
+this code is loaded into.
+
+The function itself is relatively straightforward:
+1. Parse the template
+1. Decode input data
+1. Execute the template
+
+Error handling is a bit "fast and loose" here, I opted to keep things simple by
+returning a single string that will be rendered into the output in order to
+display error messages directly to the user. That could be split out for a more
+customized UI by returning a structured object for the result.
+
+{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/exp/go-templates/main.go#L16-L44" >}}
+
+With that code in place, we need to build it into the `.wasm` file that will be
+executed within the browser environment. There are two pieces to that puzzle.
+First, the WASM produced by Go is not be directly interpretable by the browser.
+There is an intermediate layer in a file called `wasm_exec.js` which provides
+several utilities for initialization. We'll see how that's used in a moment, but
+for now we are just copying it into our `TARGET` directory for inclusion with
+the site.
+
+The next section here is for compiling the WASM itself. That is achieved with
+the standard `go build` command, merely by adding in `GOOS=js GOARCH=wasm` as
+environment variables. The `$@` Makefile syntax reverences the name of the
+current rule, producing a file called `go-templates.wasm` for us. The latter
+portion of that rule which specifies `$(wildcard *.go **/*.go)` indicates that
+this rule should re-run whenever those files change.
+
+{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/exp/go-templates/Makefile#L9-L17" >}}
+
+## Bringing WASM into the UI
+
+Now that we have our `wasm_exec.js` and `.wasm` files in hand, we need to pull
+them into our browser application. We'll do this in both places using
+[Hugo][hugo] templating logic, upon which this site is built. In the below
+snippet, we can actually pull the reference to the WASM file into a Go template
+variable within a comment (so that JS syntax highlighting/linting is
+undisturbed) using [Hugo Pipes][hugoPipes], and then pass that link into our
+[Preact][preact] component for use at initialization time. By using Hugo Pipes,
+we can add a hash to the filename, allowing for longer duration caching in the
+browser, which is particularly useful here since these the WASM files are
+somewhat sizable.
+
+{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/assets/js/exp/go-templates.tpl.jsx#L10-L17" >}}
+
+We then pull in Go's `wasm_exec.js` wrapper in similar fashion, using Hugo
+Pipes, but in this case as it's a standard `.js` file we can put it directly
+within a script tag, SRI hash and all.
+
+{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/layouts/partials/footer.html#L35-L40" >}}
+
+With those two pieces in place, we are now ready to initialize the WASM-based
+functionality. The following Javascript function is called from within our
+main [Preact][[preact] class for rendering the application, which is where the state
+management here comes in.
+
+There are two pieces of the WebAssembly puzzle here that are worth noting. First
+is the call to `new Go()`, which activates the logic we brought in
+`wasm_exec.js` earlier. Second is the call to
+[`WebAssembly.instantiateStreaming`][wasmInstantiateStreaming], which uses the
+path to the WASM file that we got earlier via Hugo Pipes, and starts pulling in
+that WASM file and instantiating it as it is streaming in from the server. This
+is generally the most efficient way to pull in WASM code. We pass in
+`go.importObject` as the `importObject` parameter to this function, which maps
+the WASM assembly into our running application in a useful way.
+
+Once this is complete, we either mark it as successful, which causes the
+application to perform it's first template rendering, or we mark the error
+accordingly and display it to the user. The error display is useful here in
+particular because WASM is not well-supported on older browser environments.
+
+{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/assets/js/exp/playground.jsx#L46-L71" >}}
+
+The rest of the app is a relatively straightforward Preact (React-style)
+application. It is somewhat monolithic as it is a relatively simple use case,
+but gets the job done. You can see the file in it's entirety here:
+
+[assets/js/exp/playground.jsx](https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/assets/js/exp/playground.jsx)
+
+One piece of interest is where the WASM code is invoked here. The `newState`
+method is a helper to produce the next version of the Preact "state" that is
+used to render the application in it's current form. This method is called at
+various locations to add the newly rendered template state, using the
+`ExpRenderGoTemplate` global function exposed from the Go WASM, to the overall
+Preact state.
+
+{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/assets/js/exp/playground.jsx#L27-L44" >}}
+
+To tie things off, I added a basic end to end test to ensure that the basic
+functionality keeps working moving forward. These tests are written in puppeteer
+and because I already had them up and running for other areas of the website, it
+was as simple as adding the test case below.
+
+{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/e2e/site.test.js#L46-L66" >}}
+
+## Odds and ends
+
+It is definitely worth noting that there are other technologies out there that
+could be used for this sort of thing, most notably [GopherJS][gopherjs]. Rather
+than compiling to WASM, GopherJS takes the approach of compiling into Javascript
+code that can then run directly in the browser. This results in a standard
+Javascript file that you can use like any other, avoiding the complexities of
+bundle size. It also results in a smaller file that the browser needs to load,
+as the entire Go runtime doesn't need to be brought along. For these reasons,
+it's a solid option and may be the better choice here. However, WASM is a really
+exciting technology on the horizon[^noNeedForDocker], so I was biased towards it
+going in, which swayed me in that direction.
+
+One thorn in the side of this project was that I did need to modify my
+`Content-Security-Policy` to get it to load in all browsers. I use Firefox as my
+daily driver, where this all works just fine, but in order for it to work in all
+of Safari, Chrome, and Edge I needed to add `unsafe-eval` to the `script-src`
+directive, allowing the WebAssembly to be brought in directly. I soon hope to
+swap this out for `wasm-unsafe-eval` which is a recent replacement[^cspWASM].
+Further beyond that however, WASM needs a mechanism to be loaded in that is not
+termed "unsafe".
+
+vim editor settings needed tweaking to work with the file:
+Another note for someone wading into these waters is that your editor by default
+may not have its tooling setup to work with the `GOOS=js GOARCH=wasm` targets,
+and is likely to have some errors in trying to perform normal operations on
+files referencing `syscall/js`. To get around that, you can hopefully do some
+sort of directory-specific customization, which is what I did here for my setup
+of Vim with `gopls`.
+
+{{< emgithub "https://github.com/kujenga/website/blob/e1a4754c5964d0a3aa5e33236628f0d829d6508f/exp/go-templates/.vim/coc-settings.json#L3-L6" >}}
+
+Future work on this tool could extended the templating functions provided by the
+standard library with additional ones, such as the
+https://github.com/Masterminds/sprig functionality that is provided in Helm and Hugo.
+
+<!-- Citations -->
+[^others]: One inspiration for this project was
+  http://jinja.quantprogramming.com/ which provides similar functionality for
+  the [jinja](https://github.com/pallets/jinja/) templating language. I used
+  their overall visual UI layout as a starting point for this project.
+[^noNeedForDocker]: There is a rather fun tweet from one of the creators
+  of Docker: "If WASM+WASI existed in 2008, we wouldn't have needed to created
+  Docker": https://twitter.com/solomonstre/status/1111004913222324225
+[^cspWASM]: More details on this are captured here:
+  https://github.com/kujenga/website/issues/60
 
 <!-- Links -->
+[helm]: https://helm.sh/
+[hugo]: https://gohugo.io/
 [playground]: /exp/go-templates/
+[ghExpTemplates]: https://github.com/kujenga/website/tree/main/exp/go-templates
+[goSyscallJS]: https://pkg.go.dev/syscall/js
+[golangbotWASM]: https://golangbot.com/webassembly-using-go/
+[goSyscallJSFuncOf]: https://pkg.go.dev/syscall/js#FuncOf
+[hugoPipes]: https://gohugo.io/hugo-pipes/introduction/#find-resources-in-assets
+[wasmInstantiateStreaming]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
+[gopherjs]: https://github.com/gopherjs/gopherjs


### PR DESCRIPTION
This provides a basic walkthrough of how the page works and how I implemented the changes for it.