### PR TITLE
Fix window.location mocking in search tests for jsdom v25+

### DIFF
--- a/assets/js/search.test.jsx
+++ b/assets/js/search.test.jsx
@@ -101,22 +101,17 @@ describe('update', () => {
 });
 
 describe('initialize', () => {
-  // Mock window location based on:
-  // https://remarkablemark.org/blog/2018/11/17/mock-window-location/
-  const { location } = window;
-
   beforeAll(() => {
-    delete window.location;
-    window.location = { reload: jest.fn() };
-
-    // Setup the window.location with a parsable URL.
-    window.location.search = '?query=sg-1';
+    // Set the URL query parameter using the history API, which is supported
+    // by jsdom without triggering navigation errors (unlike direct
+    // window.location assignment which is blocked in jsdom v25+).
+    window.history.pushState({}, '', '?query=sg-1');
     // Set up document body, mirroring the HTML site.
     document.body.innerHTML = searchHTML;
   });
 
   afterAll(() => {
-    window.location = location;
+    window.history.pushState({}, '', '/');
   });
 
   test('initialize with basic query', () => {


### PR DESCRIPTION
## Summary
Updated the test setup in `search.test.jsx` to use the History API instead of directly assigning to `window.location`, which is blocked in jsdom v25+.

## Key Changes
- Replaced `window.location` mocking with `window.history.pushState()` to set query parameters
- Removed manual `window.location` deletion and restoration in `beforeAll`/`afterAll` hooks
- Updated `afterAll` cleanup to reset the URL using `pushState` instead of restoring the original location object

## Implementation Details
The History API approach (`window.history.pushState({}, '', '?query=sg-1')`) is natively supported by jsdom without triggering navigation errors, making it more compatible with modern jsdom versions while maintaining the same test behavior of setting the URL query parameter.

https://claude.ai/code/session_01JYxVT9c15iPLsH2qiv1xd2