### PR TITLE
feat: dark mode via Bootstrap 5.3 migration, system default + persistent toggle

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "hugo-dev",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "start"],
+      "port": 1313,
+      "autoPort": false
+    },
+    {
+      "name": "go-prod",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "start:prod"],
+      "port": 8080
+    }
+  ]
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,8 @@
 module.exports = {
+  // Stop ESLint from cascading to configs above the project root, which
+  // otherwise double-loads plugins when working from a nested git worktree
+  // (e.g. .claude/worktrees/*).
+  root: true,
   plugins: ['jest'],
   env: {
     browser: true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,8 @@
     "stylelint-prettier/recommended"
   ],
   "rules": {
-    "prettier/prettier": true
+    "prettier/prettier": true,
+    "media-feature-range-notation": "prefix"
   },
   "ignoreFiles": ["layouts/**/*.html"]
 }

--- a/app/site/content-security-policy.txt
+++ b/app/site/content-security-policy.txt
@@ -1,7 +1,7 @@
 default-src 'self';
-script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://code.jquery.com https://cdn.jsdelivr.net https://stackpath.bootstrapcdn.com https://f.ataylor.io https://polyfill.io https://cdn.jsdelivr.net https://giscus.app;
-style-src 'self' 'unsafe-inline' https://stackpath.bootstrapcdn.com https://cdn.jsdelivr.net https://fonts.bunny.net https://giscus.app;
+script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net https://f.ataylor.io https://polyfill.io https://giscus.app;
+style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.bunny.net https://giscus.app;
 img-src 'self' data: https://f.ataylor.io;
-font-src data: https://stackpath.bootstrapcdn.com https://fonts.bunny.net https://cdn.jsdelivr.net;
+font-src data: https://fonts.bunny.net https://cdn.jsdelivr.net;
 connect-src 'self' https://f.ataylor.io https://raw.githubusercontent.com;
 frame-src https://giscus.app;

--- a/assets/js/exp/playground.jsx
+++ b/assets/js/exp/playground.jsx
@@ -161,8 +161,10 @@ class Playground extends Component {
     return (
       <div class="row">
         <div class="col">
-          <div class="form-group">
-            <label for="templateTextArea">Template</label>
+          <div class="mb-3">
+            <label class="form-label" for="templateTextArea">
+              Template
+            </label>
             <textarea
               class="form-control mono"
               id="templateTextArea"
@@ -172,14 +174,14 @@ class Playground extends Component {
               autocomplete="off"
             />
           </div>
-          <div class="form-group">
-            <div class="form-inline">
+          <div class="mb-3">
+            <div class="d-flex align-items-center">
               <label for="dataTextArea">Data</label>
               <label class="visually-hidden" for="dataFormat">
                 Format
               </label>
               <select
-                class="custom-select custom-select-sm ms-2 mb-1"
+                class="form-select form-select-sm w-auto ms-2 mb-1"
                 id="dataFormat"
                 value={state.dataFormat}
                 onChange={this.updateDataFormat}
@@ -202,13 +204,15 @@ class Playground extends Component {
           </div>
         </div>
         <div class="col">
-          <div class="form-group">
-            <label for="renderTextArea">Rendered</label>
+          <div class="mb-3">
+            <label class="form-label" for="renderTextArea">
+              Rendered
+            </label>
             {renderOutput}
           </div>
-          <div class="form-group">
-            <label>Configuration</label>
-            <div class="form-inline">
+          <div class="mb-3">
+            <label class="form-label">Configuration</label>
+            <div class="d-flex align-items-center">
               <button
                 type="submit"
                 class="btn btn-primary"
@@ -217,20 +221,20 @@ class Playground extends Component {
               >
                 Render
               </button>
-              <div class="custom-control custom-switch ms-3">
+              <div class="form-check form-switch ms-3">
                 <input
                   type="checkbox"
-                  class="custom-control-input"
+                  class="form-check-input"
                   id="autoRender"
                   checked={state.autoRender}
                   onClick={this.toggleAutoRender}
                 />
-                <label class="custom-control-label" for="autoRender">
+                <label class="form-check-label" for="autoRender">
                   Auto-render
                 </label>
               </div>
             </div>
-            <div class="form-inline mt-2">
+            <div class="mt-2">
               <button
                 type="button"
                 class="btn btn-secondary"
@@ -239,7 +243,7 @@ class Playground extends Component {
                 Restore Defaults
               </button>
             </div>
-            <div class="form-inline mt-2">
+            <div class="mt-2">
               <div class="form-check">
                 <input
                   class="form-check-input"
@@ -248,7 +252,7 @@ class Playground extends Component {
                   checked={state.enableSprig}
                   onClick={this.toggleEnableSprig}
                 />
-                <label class="form-check-label" for="defaultCheck1">
+                <label class="form-check-label" for="enableSprig">
                   <a
                     target="_blank"
                     rel="noreferrer"

--- a/assets/js/exp/playground.jsx
+++ b/assets/js/exp/playground.jsx
@@ -152,7 +152,7 @@ class Playground extends Component {
       renderOutput = (
         <div class="d-flex justify-content-center">
           <div class="spinner-border text-secondary" role="status">
-            <span class="sr-only">Loading...</span>
+            <span class="visually-hidden">Loading...</span>
           </div>
         </div>
       );
@@ -175,11 +175,11 @@ class Playground extends Component {
           <div class="form-group">
             <div class="form-inline">
               <label for="dataTextArea">Data</label>
-              <label class="sr-only" for="dataFormat">
+              <label class="visually-hidden" for="dataFormat">
                 Format
               </label>
               <select
-                class="custom-select custom-select-sm ml-2 mb-1"
+                class="custom-select custom-select-sm ms-2 mb-1"
                 id="dataFormat"
                 value={state.dataFormat}
                 onChange={this.updateDataFormat}
@@ -217,7 +217,7 @@ class Playground extends Component {
               >
                 Render
               </button>
-              <div class="custom-control custom-switch ml-3">
+              <div class="custom-control custom-switch ms-3">
                 <input
                   type="checkbox"
                   class="custom-control-input"

--- a/assets/js/search.jsx
+++ b/assets/js/search.jsx
@@ -1,4 +1,3 @@
-/* global $ */
 import { h, render } from 'preact';
 import lunr from 'lunr';
 
@@ -232,16 +231,19 @@ function initialize() {
     update(query);
   }
 
-  // Live update the query results as people type on the page.
-  // (conditional since tests do not have jQuery at present)
-  $('form#search').on(
-    'keyup change paste',
-    'input, select, textarea',
-    function () {
-      const query = $(this).val();
-      update(query);
-    }
-  );
+  // Live update the query results as people type on the page. Events are
+  // delegated from the form so any input, select, or textarea is covered.
+  const form = document.querySelector('form#search');
+  if (form) {
+    const onEdit = (event) => {
+      if (event.target.matches('input, select, textarea')) {
+        update(event.target.value);
+      }
+    };
+    ['keyup', 'change', 'paste'].forEach((name) =>
+      form.addEventListener(name, onEdit)
+    );
+  }
 }
 
 // At load time, setup the web page.

--- a/assets/js/search.test.jsx
+++ b/assets/js/search.test.jsx
@@ -1,4 +1,3 @@
-/* global $ */
 import { readFileSync } from 'fs';
 import { h } from 'preact';
 
@@ -6,11 +5,6 @@ beforeAll(() => {
   // Without this, h is not defined when we call the tests, for some reason.
   global.h = h;
 });
-
-// Provide jquery in a global context. This approach is used rather than a
-// direct import because jquery is used across pages and imported from a global
-// script tag so that the load is cached efficiently.
-global.$ = require('jquery');
 
 // HTML from the search page for use with tests.
 // NOTE: "build" must have been run for this to work.
@@ -131,9 +125,9 @@ describe('initialize', () => {
     // New query gets more results.
     const input = document.getElementById('search-input');
     input.value = 'stargate';
-    // Manual trigger seems to be needed with jsdom:
-    // https://www.htmlgoodies.com/javascript/testing-dom-events-using-jquery-and-jasmine-2-0/
-    $(input).trigger('keyup');
+    // Manual trigger seems to be needed with jsdom; bubbles so the delegated
+    // listener on the form sees it.
+    input.dispatchEvent(new window.Event('keyup', { bubbles: true }));
 
     // Expect three results rather than just 1 for the "stargate" query.
     const results = document.querySelectorAll('#results > ul > li');

--- a/assets/styles/main.tpl.scss
+++ b/assets/styles/main.tpl.scss
@@ -139,6 +139,11 @@ nav.navbar {
 
 .breadcrumb {
   background-color: transparent;
+
+  // Bootstrap 5 removed the default breadcrumb padding/margin; restore the
+  // Bootstrap 4 spacing this layout was designed with.
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
 }
 
 .mono {

--- a/assets/styles/main.tpl.scss
+++ b/assets/styles/main.tpl.scss
@@ -129,6 +129,18 @@ nav.navbar {
   button[type='submit']:hover {
     opacity: 1;
   }
+
+  // Mute the color mode toggle to match the search box's quiet treatment
+  // (same gray + opacity as the search icon) so it doesn't draw more
+  // attention than neighboring controls.
+  #theme-toggle {
+    color: var(--bs-secondary-color);
+    opacity: 0.7;
+  }
+
+  #theme-toggle:hover {
+    opacity: 1;
+  }
 }
 
 .lead {

--- a/assets/styles/main.tpl.scss
+++ b/assets/styles/main.tpl.scss
@@ -101,6 +101,13 @@ nav.navbar {
 }
 
 .jumbotron {
+  // Bootstrap 5 removed .jumbotron; these first properties recreate the
+  // Bootstrap 4.5 component styles this page was built against.
+  // https://getbootstrap.com/docs/5.3/migration/#jumbotron
+  padding: 2rem 1rem;
+  margin-bottom: 2rem;
+  border-radius: 0.3rem;
+
   margin-top: -25px;
   color: black;
 
@@ -108,6 +115,10 @@ nav.navbar {
   background: url('{{ (resources.Get "images/view-tall-comp.jpg" | fingerprint "md5").RelPermalink }}');
   background-position: center;
   background-size: cover;
+
+  @media (min-width: 576px) {
+    padding: 4rem 2rem;
+  }
 }
 
 .jumbotron > .container {

--- a/assets/styles/main.tpl.scss
+++ b/assets/styles/main.tpl.scss
@@ -269,6 +269,10 @@ nav.navbar {
 /* Blog Post */
 .type-blog {
   #content {
+    // Cap the text measure for readability; ~70ch tracks the body font and
+    // holds at every breakpoint, unlike percentage-based grid columns.
+    max-width: 70ch;
+
     .h1,
     .h2,
     .h3,

--- a/assets/styles/main.tpl.scss
+++ b/assets/styles/main.tpl.scss
@@ -5,6 +5,22 @@
 // https://gohugo.io/content-management/syntax-highlighting/#highlighting-in-code-fences
 @import 'syntax-github';
 
+// Dark color mode, driven by data-bs-theme on <html> (set from the system
+// preference or the stored navbar-toggle choice by the script in
+// header-includes.html). Custom styles below use Bootstrap's semantic CSS
+// variables (--bs-body-bg, --bs-border-color, ...) so they adapt on their
+// own; this block holds the pieces that need explicit dark values.
+[data-bs-theme='dark'] {
+  // Native form controls and scrollbars follow the theme.
+  color-scheme: dark;
+
+  // Dark syntax highlighting for code fences. A nested @import is the only
+  // way to scope the generated stylesheet under this selector with libsass
+  // (no @use support), hence the lint exemption.
+  // stylelint-disable-next-line no-invalid-position-at-import-rule
+  @import 'syntax-github-dark';
+}
+
 /* ref: https://coolors.co/555b6e-89b0ae-bee3db-faf9f9-ffd6ba */
 $independence: #555b6eff;
 $morning-blue: #89b0aeff;
@@ -24,7 +40,9 @@ $bootstrap-border: #ced4da;
 $links: #2d70b9;
 
 /* SVG */
-$search-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' class='bi bi-search' viewBox='0 0 16 16'%3E%3Cpath d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'%3E%3C/path%3E%3C/svg%3E");
+// fill is a fixed mid-gray so the icon stays visible in both color modes
+// (data URIs cannot reference CSS variables).
+$search-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' class='bi bi-search' viewBox='0 0 16 16'%3E%3Cpath fill='%23888888' d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z'%3E%3C/path%3E%3C/svg%3E");
 
 /* SCSS */
 
@@ -60,15 +78,15 @@ code {
 
 .small,
 small {
-  color: #777;
+  color: var(--bs-secondary-color);
 }
 
 .muted {
-  color: #777;
+  color: var(--bs-secondary-color);
 }
 
 figcaption {
-  color: #777 !important;
+  color: var(--bs-secondary-color) !important;
   font-size: 0.8rem !important;
 }
 
@@ -87,9 +105,9 @@ nav.navbar {
   // Styles for input search box based on:
   // https://tippingpoint.dev/search-icon-inside-input
   form#search {
-    border: 1px solid $bootstrap-border;
+    border: 1px solid var(--bs-border-color);
     border-radius: 5px;
-    background: white;
+    background: var(--bs-body-bg);
   }
 
   input[type='search'] {
@@ -98,13 +116,13 @@ nav.navbar {
   }
 
   input[type='search']::placeholder {
-    color: #bbb;
+    color: var(--bs-tertiary-color);
   }
 
   button[type='submit'] {
     height: 40px;
     width: 40px;
-    background: white $search-icon no-repeat center;
+    background: var(--bs-body-bg) $search-icon no-repeat center;
     opacity: 0.7;
   }
 
@@ -163,25 +181,14 @@ nav.navbar {
 .footer {
   margin-top: 50px;
   margin-bottom: 25px;
-  border: solid 1px #eee;
-  background: linear-gradient(
-    #eee,
-    #fff,
-    #fff,
-    #fff,
-    #fff
-  ); /* For:
-  - Safari 5.1 to 6.0
-  - Opera 11.1 to 12.0
-  - Firefox 3.6 to 15 */
-
+  border: solid 1px var(--bs-border-color);
   background: repeating-linear-gradient(
-    #eee,
-    #fff,
-    #fff,
-    #fff,
-    #fff
-  ); /* Standard syntax */
+    var(--bs-secondary-bg),
+    var(--bs-body-bg),
+    var(--bs-body-bg),
+    var(--bs-body-bg),
+    var(--bs-body-bg)
+  );
 }
 
 .copyright {
@@ -308,7 +315,7 @@ nav.navbar {
 
   pre {
     border-radius: 0.3rem 0.3rem 0 0;
-    border: 1px solid #ddd;
+    border: 1px solid var(--bs-border-color);
     padding: 0.5rem 1rem;
     font-size: 80%;
     line-height: 1.05rem;
@@ -337,7 +344,7 @@ nav.navbar {
 .btn-outline.active {
   color: #999;
   border: solid 2px #999;
-  background: #fff;
+  background: var(--bs-body-bg);
 }
 
 .btn-social {

--- a/assets/styles/main.tpl.scss
+++ b/assets/styles/main.tpl.scss
@@ -34,6 +34,14 @@ body {
 
 a {
   color: $links;
+
+  // Bootstrap 5 underlines links by default; restore the Bootstrap 4
+  // underline-on-hover-only behavior this site was designed around.
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 code {
@@ -107,7 +115,6 @@ nav.navbar {
   padding: 2rem 1rem;
   margin-bottom: 2rem;
   border-radius: 0.3rem;
-
   margin-top: -25px;
   color: black;
 
@@ -116,6 +123,9 @@ nav.navbar {
   background-position: center;
   background-size: cover;
 
+  // Prefix notation required: Hugo's toCSS/libsass cannot parse the modern
+  // range syntax (width >= 576px); see media-feature-range-notation in
+  // .stylelintrc.json.
   @media (min-width: 576px) {
     padding: 4rem 2rem;
   }

--- a/assets/styles/main.tpl.scss
+++ b/assets/styles/main.tpl.scss
@@ -269,10 +269,6 @@ nav.navbar {
 /* Blog Post */
 .type-blog {
   #content {
-    // Cap the text measure for readability; ~70ch tracks the body font and
-    // holds at every breakpoint, unlike percentage-based grid columns.
-    max-width: 70ch;
-
     .h1,
     .h2,
     .h3,

--- a/assets/styles/main.tpl.scss
+++ b/assets/styles/main.tpl.scss
@@ -32,6 +32,15 @@ body {
   font-family: Lato, sans-serif;
 }
 
+// Bootstrap 5 added an xxl breakpoint (>=1400px viewport) that grows the
+// container to 1320px; keep the Bootstrap 4 maximum of 1140px so wide
+// screens match the layout this site was designed around.
+@media (min-width: 1400px) {
+  .container {
+    max-width: 1140px;
+  }
+}
+
 a {
   color: $links;
 

--- a/assets/styles/syntax-github-dark.scss
+++ b/assets/styles/syntax-github-dark.scss
@@ -1,0 +1,361 @@
+/** Syntax Highlighting (dark)
+ *
+ * Generated with the following command, for use within [data-bs-theme='dark']:
+ *
+ *     hugo gen chromastyles --style=github-dark
+ *
+ */
+
+/* stylelint-disable color-hex-length, block-no-empty, comment-empty-line-before, property-no-vendor-prefix */
+
+/* Background */
+.bg {
+  color: #e6edf3;
+  background-color: #0d1117;
+}
+/* PreWrapper */
+.chroma {
+  color: #e6edf3;
+  background-color: #0d1117;
+  -webkit-text-size-adjust: none;
+}
+/* Error */
+.chroma .err {
+  color: #f85149;
+}
+/* LineLink */
+.chroma .lnlinks {
+  outline: none;
+  text-decoration: none;
+  color: inherit;
+}
+/* LineTableTD */
+.chroma .lntd {
+  vertical-align: top;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+/* LineTable */
+.chroma .lntable {
+  border-spacing: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+/* LineHighlight */
+.chroma .hl {
+  background-color: #6e7681;
+}
+/* LineNumbersTable */
+.chroma .lnt {
+  white-space: pre;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-right: 0.4em;
+  padding: 0 0.4em;
+  color: #737679;
+}
+/* LineNumbers */
+.chroma .ln {
+  white-space: pre;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-right: 0.4em;
+  padding: 0 0.4em;
+  color: #6e7681;
+}
+/* Line */
+.chroma .line {
+  display: flex;
+}
+/* Keyword */
+.chroma .k {
+  color: #ff7b72;
+}
+/* KeywordConstant */
+.chroma .kc {
+  color: #79c0ff;
+}
+/* KeywordDeclaration */
+.chroma .kd {
+  color: #ff7b72;
+}
+/* KeywordNamespace */
+.chroma .kn {
+  color: #ff7b72;
+}
+/* KeywordPseudo */
+.chroma .kp {
+  color: #79c0ff;
+}
+/* KeywordReserved */
+.chroma .kr {
+  color: #ff7b72;
+}
+/* KeywordType */
+.chroma .kt {
+  color: #ff7b72;
+}
+/* NameClass */
+.chroma .nc {
+  color: #f0883e;
+  font-weight: bold;
+}
+/* NameConstant */
+.chroma .no {
+  color: #79c0ff;
+  font-weight: bold;
+}
+/* NameDecorator */
+.chroma .nd {
+  color: #d2a8ff;
+  font-weight: bold;
+}
+/* NameEntity */
+.chroma .ni {
+  color: #ffa657;
+}
+/* NameException */
+.chroma .ne {
+  color: #f0883e;
+  font-weight: bold;
+}
+/* NameLabel */
+.chroma .nl {
+  color: #79c0ff;
+  font-weight: bold;
+}
+/* NameNamespace */
+.chroma .nn {
+  color: #ff7b72;
+}
+/* NameProperty */
+.chroma .py {
+  color: #79c0ff;
+}
+/* NameTag */
+.chroma .nt {
+  color: #7ee787;
+}
+/* NameVariable */
+.chroma .nv {
+  color: #79c0ff;
+}
+/* NameVariableClass */
+.chroma .vc {
+  color: #79c0ff;
+}
+/* NameVariableGlobal */
+.chroma .vg {
+  color: #79c0ff;
+}
+/* NameVariableInstance */
+.chroma .vi {
+  color: #79c0ff;
+}
+/* NameVariableMagic */
+.chroma .vm {
+  color: #79c0ff;
+}
+/* NameFunction */
+.chroma .nf {
+  color: #d2a8ff;
+  font-weight: bold;
+}
+/* NameFunctionMagic */
+.chroma .fm {
+  color: #d2a8ff;
+  font-weight: bold;
+}
+/* Literal */
+.chroma .l {
+  color: #a5d6ff;
+}
+/* LiteralDate */
+.chroma .ld {
+  color: #79c0ff;
+}
+/* LiteralString */
+.chroma .s {
+  color: #a5d6ff;
+}
+/* LiteralStringAffix */
+.chroma .sa {
+  color: #79c0ff;
+}
+/* LiteralStringBacktick */
+.chroma .sb {
+  color: #a5d6ff;
+}
+/* LiteralStringChar */
+.chroma .sc {
+  color: #a5d6ff;
+}
+/* LiteralStringDelimiter */
+.chroma .dl {
+  color: #79c0ff;
+}
+/* LiteralStringDoc */
+.chroma .sd {
+  color: #a5d6ff;
+}
+/* LiteralStringDouble */
+.chroma .s2 {
+  color: #a5d6ff;
+}
+/* LiteralStringEscape */
+.chroma .se {
+  color: #79c0ff;
+}
+/* LiteralStringHeredoc */
+.chroma .sh {
+  color: #79c0ff;
+}
+/* LiteralStringInterpol */
+.chroma .si {
+  color: #a5d6ff;
+}
+/* LiteralStringOther */
+.chroma .sx {
+  color: #a5d6ff;
+}
+/* LiteralStringRegex */
+.chroma .sr {
+  color: #79c0ff;
+}
+/* LiteralStringSingle */
+.chroma .s1 {
+  color: #a5d6ff;
+}
+/* LiteralStringSymbol */
+.chroma .ss {
+  color: #a5d6ff;
+}
+/* LiteralNumber */
+.chroma .m {
+  color: #a5d6ff;
+}
+/* LiteralNumberBin */
+.chroma .mb {
+  color: #a5d6ff;
+}
+/* LiteralNumberFloat */
+.chroma .mf {
+  color: #a5d6ff;
+}
+/* LiteralNumberHex */
+.chroma .mh {
+  color: #a5d6ff;
+}
+/* LiteralNumberInteger */
+.chroma .mi {
+  color: #a5d6ff;
+}
+/* LiteralNumberIntegerLong */
+.chroma .il {
+  color: #a5d6ff;
+}
+/* LiteralNumberOct */
+.chroma .mo {
+  color: #a5d6ff;
+}
+/* Operator */
+.chroma .o {
+  color: #ff7b72;
+  font-weight: bold;
+}
+/* OperatorWord */
+.chroma .ow {
+  color: #ff7b72;
+  font-weight: bold;
+}
+/* Comment */
+.chroma .c {
+  color: #8b949e;
+  font-style: italic;
+}
+/* CommentHashbang */
+.chroma .ch {
+  color: #8b949e;
+  font-style: italic;
+}
+/* CommentMultiline */
+.chroma .cm {
+  color: #8b949e;
+  font-style: italic;
+}
+/* CommentSingle */
+.chroma .c1 {
+  color: #8b949e;
+  font-style: italic;
+}
+/* CommentSpecial */
+.chroma .cs {
+  color: #8b949e;
+  font-weight: bold;
+  font-style: italic;
+}
+/* CommentPreproc */
+.chroma .cp {
+  color: #8b949e;
+  font-weight: bold;
+  font-style: italic;
+}
+/* CommentPreprocFile */
+.chroma .cpf {
+  color: #8b949e;
+  font-weight: bold;
+  font-style: italic;
+}
+/* GenericDeleted */
+.chroma .gd {
+  color: #ffa198;
+  background-color: #490202;
+}
+/* GenericEmph */
+.chroma .ge {
+  font-style: italic;
+}
+/* GenericError */
+.chroma .gr {
+  color: #ffa198;
+}
+/* GenericHeading */
+.chroma .gh {
+  color: #79c0ff;
+  font-weight: bold;
+}
+/* GenericInserted */
+.chroma .gi {
+  color: #56d364;
+  background-color: #0f5323;
+}
+/* GenericOutput */
+.chroma .go {
+  color: #8b949e;
+}
+/* GenericPrompt */
+.chroma .gp {
+  color: #8b949e;
+}
+/* GenericStrong */
+.chroma .gs {
+  font-weight: bold;
+}
+/* GenericSubheading */
+.chroma .gu {
+  color: #79c0ff;
+}
+/* GenericTraceback */
+.chroma .gt {
+  color: #ff7b72;
+}
+/* GenericUnderline */
+.chroma .gl {
+  text-decoration: underline;
+}
+/* TextWhitespace */
+.chroma .w {
+  color: #6e7681;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "@kujenga/website",
       "dependencies": {
-        "jquery": "^3.6.0",
         "lunr": "^2.3.9",
         "preact": "^10.25.4",
       },
@@ -827,8 +826,6 @@
 
     "jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
 
-    "jquery": ["jquery@3.7.1", "", {}, "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="],
-
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
@@ -1277,10 +1274,6 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@eslint/eslintrc/globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
-
-    "@eslint/eslintrc/js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
-
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
@@ -1291,13 +1284,7 @@
 
     "@jest/environment/@jest/types": ["@jest/types@30.3.0", "", { "dependencies": { "@jest/pattern": "30.0.1", "@jest/schemas": "30.0.5", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw=="],
 
-    "@jest/environment-jsdom-abstract/@jest/environment": ["@jest/environment@30.3.0", "", { "dependencies": { "@jest/fake-timers": "30.3.0", "@jest/types": "30.3.0", "@types/node": "*", "jest-mock": "30.3.0" } }, "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers": ["@jest/fake-timers@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@sinonjs/fake-timers": "^15.0.0", "@types/node": "*", "jest-message-util": "30.3.0", "jest-mock": "30.3.0", "jest-util": "30.3.0" } }, "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ=="],
-
     "@jest/environment-jsdom-abstract/@jest/types": ["@jest/types@30.3.0", "", { "dependencies": { "@jest/pattern": "30.0.1", "@jest/schemas": "30.0.5", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw=="],
-
-    "@jest/environment-jsdom-abstract/jest-mock": ["jest-mock@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "jest-util": "30.3.0" } }, "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog=="],
 
     "@jest/environment-jsdom-abstract/jest-util": ["jest-util@30.3.0", "", { "dependencies": { "@jest/types": "30.3.0", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg=="],
 
@@ -1323,8 +1310,6 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
-    "@typescript-eslint/typescript-estree/semver": ["semver@7.6.3", "", { "bin": "bin/semver.js" }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
-
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.0", "", {}, "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
@@ -1333,15 +1318,7 @@
 
     "cacheable/keyv": ["keyv@5.2.3", "", { "dependencies": { "@keyv/serialize": "^1.0.2" } }, "sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw=="],
 
-    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "cosmiconfig/js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
-
-    "eslint-plugin-compat/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
-
-    "eslint-plugin-compat/semver": ["semver@7.6.3", "", { "bin": "bin/semver.js" }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
 
     "eslint-plugin-jsdoc/espree": ["espree@10.3.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.0" } }, "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg=="],
 
@@ -1360,8 +1337,6 @@
     "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": "bin/which" }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
     "html-validate/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "html-validate/semver": ["semver@7.6.3", "", { "bin": "bin/semver.js" }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
 
     "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -1397,15 +1372,11 @@
 
     "jest-runtime/jest-mock": ["jest-mock@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "jest-util": "^29.7.0" } }, "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw=="],
 
-    "jest-snapshot/semver": ["semver@7.6.3", "", { "bin": "bin/semver.js" }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
-
     "jest-validate/camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "jsdom/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "make-dir/semver": ["semver@7.6.3", "", { "bin": "bin/semver.js" }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -1421,8 +1392,6 @@
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "stylelint/file-entry-cache": ["file-entry-cache@10.0.5", "", { "dependencies": { "flat-cache": "^6.1.5" } }, "sha512-umpQsJrBNsdMDgreSryMEXvJh66XeLtZUwA8Gj7rHGearGufUFv6rB/bcXRFsiGWw/VeSUgUofF4Rf2UKEOrTA=="],
 
     "stylelint/ignore": ["ignore@7.0.0", "", {}, "sha512-lcX8PNQygAa22u/0BysEY8VhaFRzlOkvdlKczDPnJvrkJD1EuqzEky5VYYKM2iySIuaVIDv9N190DfSreSLw2A=="],
@@ -1433,8 +1402,6 @@
 
     "table/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
-    "table/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
@@ -1443,27 +1410,13 @@
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@eslint/eslintrc/globals/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
-
-    "@eslint/eslintrc/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@isaacs/cliui/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.1.1", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers/jest-message-util": ["jest-message-util@30.3.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.3.0", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3", "pretty-format": "30.3.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw=="],
 
     "@jest/environment-jsdom-abstract/@jest/types/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
 
@@ -1485,19 +1438,11 @@
 
     "@jest/globals/@jest/environment/@jest/fake-timers": ["@jest/fake-timers@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@sinonjs/fake-timers": "^10.0.2", "@types/node": "*", "jest-message-util": "^29.7.0", "jest-mock": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ=="],
 
-    "@jest/reporters/istanbul-lib-instrument/semver": ["semver@7.6.3", "", { "bin": "bin/semver.js" }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
-
     "@jest/transform/write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "@nicolo-ribaudo/eslint-scope-5-internals/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
-
-    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "cosmiconfig/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "eslint-plugin-compat/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "eslint-plugin-jsdoc/espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.0", "", {}, "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="],
 
@@ -1539,25 +1484,11 @@
 
     "table/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "table/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "wrap-ansi/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
-    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "@isaacs/cliui/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
-
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers/jest-message-util/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers/jest-message-util/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
 
     "@jest/environment-jsdom-abstract/@jest/types/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
@@ -1575,8 +1506,6 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "eslint-plugin-compat/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
-
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "jest-circus/@jest/environment/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
@@ -1591,22 +1520,12 @@
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
-    "wrap-ansi/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
-
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers/jest-message-util/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers/jest-message-util/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers/jest-message-util/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "@jest/fake-timers/jest-message-util/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
     "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "@jest/environment-jsdom-abstract/@jest/fake-timers/jest-message-util/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
   }
 }

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,17 +1,30 @@
-<script
-  src="https://giscus.app/client.js"
-  data-repo="kujenga/website"
-  data-repo-id="MDEwOlJlcG9zaXRvcnkyNjU4MDg4MQ=="
-  data-category="Blog Post Comments"
-  data-category-id="DIC_kwDOAZWXkc4CAC59"
-  data-mapping="og:title"
-  data-reactions-enabled="1"
-  data-emit-metadata="0"
-  data-theme="light"
-  data-lang="en"
-  crossorigin="anonymous"
-  async
-></script>
+<!-- The giscus script is injected dynamically so its initial data-theme can
+     match the active color mode (set on <html> by the theme script in
+     header-includes); later changes are synced via postMessage there. -->
+<script>
+  (() => {
+    const giscus = document.createElement('script');
+    giscus.src = 'https://giscus.app/client.js';
+    giscus.async = true;
+    giscus.crossOrigin = 'anonymous';
+    const config = {
+      'data-repo': 'kujenga/website',
+      'data-repo-id': 'MDEwOlJlcG9zaXRvcnkyNjU4MDg4MQ==',
+      'data-category': 'Blog Post Comments',
+      'data-category-id': 'DIC_kwDOAZWXkc4CAC59',
+      'data-mapping': 'og:title',
+      'data-reactions-enabled': '1',
+      'data-emit-metadata': '0',
+      'data-theme':
+        document.documentElement.getAttribute('data-bs-theme') || 'light',
+      'data-lang': 'en',
+    };
+    for (const [key, value] of Object.entries(config)) {
+      giscus.setAttribute(key, value);
+    }
+    document.currentScript.insertAdjacentElement('afterend', giscus);
+  })();
+</script>
 <noscript
   >Please enable JavaScript to view the
   <a href="https://github.com/giscus/giscus" rel="nofollow"

--- a/layouts/partials/footer-social.html
+++ b/layouts/partials/footer-social.html
@@ -16,7 +16,10 @@
       </div>
       <!-- Bug report link -->
       {{ if .Params.bugReports }}
-      <div class="bug-report float-end">
+      <!-- col-sm-auto: in Bootstrap 5 every .row child gets width:100%, so a
+           bare floated div would take its own line; an auto column after the
+           growing .col-sm keeps it pulled to the right edge as before. -->
+      <div class="col-sm-auto bug-report">
         <p class="text-muted">
           <a
             target="_blank"

--- a/layouts/partials/footer-social.html
+++ b/layouts/partials/footer-social.html
@@ -16,7 +16,7 @@
       </div>
       <!-- Bug report link -->
       {{ if .Params.bugReports }}
-      <div class="bug-report float-right">
+      <div class="bug-report float-end">
         <p class="text-muted">
           <a
             target="_blank"
@@ -32,7 +32,7 @@
       <!-- Social links -->
       {{ if not .Params.disableSocial }}
       <div class="col-sm">
-        <ul class="float-right">
+        <ul class="float-end">
           <li class="list-inline-item">
             <a
               href="{{ .Site.Params.linkedin }}"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,20 +1,10 @@
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
+<!-- The bundle includes Popper; Bootstrap 5 has no jQuery dependency -->
 <script
-  src="https://code.jquery.com/jquery-3.6.0.slim.min.js"
-  integrity="sha384-Qg00WFl9r0Xr6rUqNLv1ffTSSKEFFCDCKVyHZ+sVt8KuvG99nWw5RNvbhuKgif9z"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-  integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-  crossorigin="anonymous"
-></script>
-<!-- Latest compiled and minified JavaScript -->
-<script
-  src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"
-  integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
+  src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
   crossorigin="anonymous"
 ></script>
 <!-- Add anchor links to posts: https://www.bryanbraun.com/anchorjs/ -->
@@ -48,22 +38,15 @@ resources.Fingerprint "sha256" }}
 </script>
 
 <script>
-  var jumboHeight = $('.jumbotron').outerHeight();
-  function parallax() {
-    var scrolled = $(window).scrollTop();
-    $('.bg').css('height', jumboHeight - scrolled + 'px');
-  }
-
-  $(window).scroll(function (e) {
-    parallax();
-  });
-</script>
-
-<script>
   // highlight menu bar appropriately: http://stackoverflow.com/questions/11813498/make-twitter-bootstrap-navbar-link-active#answer-25082875
-  $(document).ready(function () {
-    $('a[href="' + this.location.pathname + '"]')
-      .parent()
-      .addClass('active');
+  document.addEventListener('DOMContentLoaded', function () {
+    document
+      .querySelectorAll(
+        '.navbar-nav a[href="' + window.location.pathname + '"]'
+      )
+      .forEach(function (link) {
+        link.classList.add('active');
+        link.setAttribute('aria-current', 'page');
+      });
   });
 </script>

--- a/layouts/partials/header-includes.html
+++ b/layouts/partials/header-includes.html
@@ -1,3 +1,72 @@
+<!-- Color mode handling, adapted from the Bootstrap 5.3 documentation:
+     https://getbootstrap.com/docs/5.3/customize/color-modes/#javascript
+     Inline and ahead of the stylesheets so the theme applies before first
+     paint. The stored preference ("light"/"dark") wins; otherwise the
+     system preference is followed, live. -->
+<script>
+  (() => {
+    'use strict';
+
+    const getStored = () => localStorage.getItem('theme');
+    const getPreferred = () => {
+      const stored = getStored();
+      if (stored === 'light' || stored === 'dark') {
+        return stored;
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+    };
+    const setTheme = (theme) => {
+      document.documentElement.setAttribute('data-bs-theme', theme);
+      // Keep the giscus comments iframe in sync, when present.
+      const giscus = document.querySelector('iframe.giscus-frame');
+      if (giscus) {
+        giscus.contentWindow.postMessage(
+          { giscus: { setConfig: { theme } } },
+          'https://giscus.app'
+        );
+      }
+    };
+
+    setTheme(getPreferred());
+    window
+      .matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', () => setTheme(getPreferred()));
+
+    // Wire up the navbar toggle once the DOM exists.
+    window.addEventListener('DOMContentLoaded', () => {
+      const reflect = () => {
+        const stored = getStored() || 'auto';
+        document.querySelectorAll('[data-theme-value]').forEach((btn) => {
+          btn.classList.toggle(
+            'active',
+            btn.getAttribute('data-theme-value') === stored
+          );
+        });
+        const icon = document.getElementById('theme-icon');
+        if (icon) {
+          const icons = { light: 'fa-sun-o', dark: 'fa-moon-o' };
+          icon.className = 'fa ' + (icons[stored] || 'fa-adjust');
+        }
+      };
+      document.querySelectorAll('[data-theme-value]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const value = btn.getAttribute('data-theme-value');
+          if (value === 'auto') {
+            localStorage.removeItem('theme');
+          } else {
+            localStorage.setItem('theme', value);
+          }
+          setTheme(getPreferred());
+          reflect();
+        });
+      });
+      reflect();
+    });
+  })();
+</script>
+
 <!-- Latest compiled and minified CSS for Bootstrap and Font Awesome -->
 <link rel="preconnect" href="https://cdn.jsdelivr.net" />
 <link

--- a/layouts/partials/header-includes.html
+++ b/layouts/partials/header-includes.html
@@ -1,13 +1,13 @@
 <!-- Latest compiled and minified CSS for Bootstrap and Font Awesome -->
-<link rel="preconnect" href="https://stackpath.bootstrapcdn.com" />
+<link rel="preconnect" href="https://cdn.jsdelivr.net" />
 <link
   rel="stylesheet"
-  href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
-  integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
+  href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+  integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
   crossorigin="anonymous"
 />
 <link
-  href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+  href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css"
   rel="stylesheet"
   integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN"
   crossorigin="anonymous"
@@ -34,9 +34,3 @@ toCSS | minify | fingerprint }}
   href="{{ $style.RelPermalink }}"
   integrity="{{ $style.Data.Integrity }}"
 />
-
-<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-<!--[if lt IE 9]>
-  <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-  <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-<![endif]-->

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -15,8 +15,8 @@
     <button
       class="navbar-toggler"
       type="button"
-      data-toggle="collapse"
-      data-target="#navbarSupportedContent"
+      data-bs-toggle="collapse"
+      data-bs-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent"
       aria-expanded="false"
       aria-label="Toggle navigation"
@@ -25,7 +25,7 @@
     </button>
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         {{ $current := . }}
         <!-- Iterate over nav menu items -->
         {{ range .Site.Menus.nav }}
@@ -33,8 +33,20 @@
         {{ $active := or (or ($current.IsMenuCurrent "nav" .)
         ($current.HasMenuCurrent "nav" .)) (hasPrefix $current.RelPermalink
         .URL) }}
-        <li class="nav-item{{ if $active }} active{{ end }}">
-          <a class="nav-link" href="{{ .URL }}">{{ .Title }}</a>
+        <!-- Bootstrap 5 styles .nav-link.active (was the parent li in v4) -->
+        <li class="nav-item">
+          <a
+            class="nav-link{{ if $active }} active{{ end }}"
+            {{
+            if
+            $active
+            }}aria-current="page"
+            {{
+            end
+            }}
+            href="{{ .URL }}"
+            >{{ .Title }}</a
+          >
         </li>
         {{ end }}
       </ul>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,4 +1,6 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-light" aria-label="Primary">
+<!-- bg-body-tertiary matches the old bg-light in light mode and follows
+     data-bs-theme in dark mode (bg-light does not). -->
+<nav class="navbar navbar-expand-lg bg-body-tertiary" aria-label="Primary">
   <div class="container">
     <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
       {{- $navImage := (resources.Get
@@ -53,6 +55,44 @@
 
       <!-- Search form -->
       {{ partial "search-form.html" . }}
+
+      <!-- Color mode toggle; wired up by the theme script in header-includes -->
+      <div class="dropdown ms-2">
+        <button
+          class="btn nav-link dropdown-toggle"
+          type="button"
+          id="theme-toggle"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+          aria-label="Toggle color theme"
+        >
+          <i class="fa fa-adjust" aria-hidden="true" id="theme-icon"></i>
+        </button>
+        <ul
+          class="dropdown-menu dropdown-menu-end"
+          aria-labelledby="theme-toggle"
+        >
+          <li>
+            <button
+              class="dropdown-item"
+              type="button"
+              data-theme-value="light"
+            >
+              <i class="fa fa-sun-o fa-fw" aria-hidden="true"></i> Light
+            </button>
+          </li>
+          <li>
+            <button class="dropdown-item" type="button" data-theme-value="dark">
+              <i class="fa fa-moon-o fa-fw" aria-hidden="true"></i> Dark
+            </button>
+          </li>
+          <li>
+            <button class="dropdown-item" type="button" data-theme-value="auto">
+              <i class="fa fa-adjust fa-fw" aria-hidden="true"></i> Auto
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </nav>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -53,11 +53,8 @@
         {{ end }}
       </ul>
 
-      <!-- Search form -->
-      {{ partial "search-form.html" . }}
-
       <!-- Color mode toggle; wired up by the theme script in header-includes -->
-      <div class="dropdown ms-2">
+      <div class="dropdown me-2">
         <button
           class="btn nav-link dropdown-toggle"
           type="button"
@@ -93,6 +90,9 @@
           </li>
         </ul>
       </div>
+
+      <!-- Search form -->
+      {{ partial "search-form.html" . }}
     </div>
   </div>
 </nav>

--- a/layouts/partials/search-form.html
+++ b/layouts/partials/search-form.html
@@ -2,7 +2,8 @@
   id="search"
   action="{{ with .GetPage `/search` }}{{ .RelPermalink }}{{ end }}"
   method="get"
-  class="form-inline"
+  class="d-flex align-items-center"
+  role="search"
 >
   <input
     type="search"

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,5 +1,5 @@
 <!-- Events captured here for Fathom: https://usefathom.com/docs/features/events -->
-<div class="col col-sm-1 ml-auto">
+<div class="col col-sm-1 ms-auto">
   <!-- Jump to the comments section -->
   <a href="#comments" aria-label="Go to comments">
     <i class="fa fa-comment-o" aria-hidden="true"></i>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -2,7 +2,7 @@
 {{ if and (gt .WordCount 400) (.Params.toc) }}
 <div class="toc">
   <aside>
-    <a data-toggle="collapse" data-target="#toc" href="#">
+    <a data-bs-toggle="collapse" data-bs-target="#toc" href="#">
       Table of Contents
       <i class="fa fa-plus" aria-hidden="true"></i>
     </a>

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -4,8 +4,8 @@
 <figure
   class="figure
           {{- with .Get `class` }} {{ . }}{{ end -}}
-          {{- if eq (.Get `loc`) `left` }} float-left{{ end -}}
-          {{- if eq (.Get `loc`) `right` }} float-right{{ end -}}
+          {{- if eq (.Get `loc`) `left` }} float-start{{ end -}}
+          {{- if eq (.Get `loc`) `right` }} float-end{{ end -}}
           {{- if eq (.Get `loc`) `center` }} mx-auto d-block{{ end -}}
     "
   style="{{ with .Get `width` }}min-width: {{ . }}; max-width: {{ . }};{{ end }}"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "stylelint-prettier": "^5.0.2"
   },
   "dependencies": {
-    "jquery": "^3.6.0",
     "lunr": "^2.3.9",
     "preact": "^10.25.4"
   }


### PR DESCRIPTION
## Why

The goal is system-preference dark mode with a user-facing override. Bootstrap 4 has no theming mechanism, so getting there idiomatically meant migrating to Bootstrap 5.3 first (`data-bs-theme` arrived in 5.3) rather than hand-maintaining a parallel dark override sheet against a frozen framework. This PR does both: the full BS4→5.3.8 migration with visual parity as a hard requirement, then dark mode on top — following the [Bootstrap color-modes pattern](https://getbootstrap.com/docs/5.3/customize/color-modes/): system preference by default (tracked live), with a navbar Light/Dark/Auto toggle persisted in localStorage.

The migration also retires legacy infrastructure in passing: the stackpath CDN host (StackPath shut down; the domain survives on redirects), jQuery + Popper 1 (BS5 needs neither; the site's own three jQuery usages were trivial to port to vanilla DOM), and the IE8 shims.

## What changed

Commits are structured for individual review — CDN swap, mechanical renames, form rebuilds, jQuery removal, parity fixes, then dark mode. See commits for detail; each body records the rationale and the BS5 behavior change that drove it (e.g. `.row > *` gaining `width: 100%`, `bg-light` not responding to themes).

Two cross-cutting notes:

- Custom SCSS colors moved to Bootstrap's semantic CSS variables (`--bs-body-bg`, `--bs-border-color`, …), which is what makes dark mode cheap to maintain — there is no parallel dark palette, only a small `[data-bs-theme='dark']` block (color-scheme + generated `github-dark` Chroma styles).
- `.container` is capped at Bootstrap 4's 1140px maximum: BS5's new xxl breakpoint (1320px at ≥1400px viewports) widened every page ~180px beyond the intended design ([main.tpl.scss](../blob/claude/dark-mode-planning-2d6ded/assets/styles/main.tpl.scss)).

## Validation

- Visual parity verified page-by-page (home, blog list, heavy blog post, about, projects, WASM playground) via full-page screenshot comparison against the pre-migration baseline, and against production for the search/breadcrumb pages and blog layout geometry (825px vs 831px content column; the 6px is BS5's narrower gutters).
- Interactions exercised in a real browser: navbar collapse at mobile width, TOC collapse, live search-as-you-type, playground render/auto-render/format controls, theme toggle.
- Dark mode state machine verified live: auto follows emulated system-scheme changes without reload; explicit choice persists across reloads and overrides the system; Auto restores following; light mode is pixel-unchanged.
- `bun run lint` (ESLint, Stylelint, html-validate, Prettier), Jest (10/10), Go tests (8/8), and Playwright e2e on Chromium (4/4) all pass against the local server. Firefox/WebKit e2e did not run locally (browser binaries not installed on this machine); CI runs the full matrix post-deploy.

## Notes

- CSP (`app/site/content-security-policy.txt`) drops stackpath and code.jquery.com; jsdelivr was already allowed. All new SRI hashes were computed locally against the fetched assets.
- Toolchain guardrails added along the way: stylelint pinned to prefix media-query notation (Hugo's libsass cannot parse range syntax), `.eslintrc.js` marked `root: true` (nested worktrees double-loaded plugins).

## Known follow-ups

- emgithub code embeds on older posts render light regardless of theme (third-party embed; would need per-embed theme params).
- No automated e2e coverage of dark mode yet; a Playwright spec with `colorScheme: 'dark'` emulation would be a natural addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
